### PR TITLE
Patchset to enable 1 GHz (OPP1G) operation on the Beagleboard xM reliabl...

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -61,6 +61,9 @@ drivers () {
 	${git} "${DIR}/patches/drivers/0002-ASoC-sglt5000-Provide-the-reg_stride-field.patch"
 	${git} "${DIR}/patches/drivers/0003-ASoC-imx-sgtl5000-fix-error-return-code-in-imx_sgtl5.patch"
 	${git} "${DIR}/patches/drivers/0004-ASoC-sgtl5000-defer-the-probe-if-clock-is-not-found.patch"
+	
+	#TI omap dts clock bindings driver
+	${git} "${DIR}/patches/drivers/0005-ARM-dts-omap-clock-bindings-driver.patch"
 }
 
 imx_dts () {
@@ -232,6 +235,15 @@ omap () {
 	#omap4: fix video..
 	${git} "${DIR}/patches/omap/0011-ARM-OMAP-dss-common-fix-Panda-s-DVI-DDC-channel.patch"
 	${git} "${DIR}/patches/omap/0012-ARM-OMAP2-Remove-legacy-DSS-initialization-for-omap4.patch"
+
+	#omap3: add device tree clock binding support
+	${git} "${DIR}/patches/omap/0014-ARM-dts-omap3-add-clock-bindings-to-dts.patch"
+	
+	#omap: use cpu0-cpufreq SoC generic driver if performing dts boot, use old method if non dts
+	${git} "${DIR}/patches/omap/0015-ARM-dts-omap-boot-support-cpu0-cpufreq.patch"
+	
+	#beagleboard-xm: add abb bindings and OPP1G operating point for 1 GHz operation
+	${git} "${DIR}/patches/omap/0016-ARM-dts-omap3-beagle-xm-add-opp1g-abb-bindings.patch"
 }
 
 dts () {

--- a/patches/drivers/0005-ARM-dts-omap-clock-bindings-driver.patch
+++ b/patches/drivers/0005-ARM-dts-omap-clock-bindings-driver.patch
@@ -1,0 +1,143 @@
+From f179ec4b6bfddc7913f31aa80a0c7d301b6adc21 Mon Sep 17 00:00:00 2001
+From: Teknoman117 <linux.robotdude@gmail.com>
+Date: Wed, 24 Jul 2013 02:57:08 -0700
+Subject: [PATCH] Added the Texas Instruments OMAP Clock driver originally
+ found here:
+ http://lkml.indiana.edu/hypermail/linux/kernel/1304.1/04079.html
+
+---
+ drivers/clk/Makefile      |    1 +
+ drivers/clk/omap/Makefile |    1 +
+ drivers/clk/omap/clk.c    |  100 +++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 102 insertions(+)
+ create mode 100644 drivers/clk/omap/Makefile
+ create mode 100644 drivers/clk/omap/clk.c
+
+diff --git a/drivers/clk/Makefile b/drivers/clk/Makefile
+index 4038c2b..8019e1d 100644
+--- a/drivers/clk/Makefile
++++ b/drivers/clk/Makefile
+@@ -31,6 +31,7 @@ obj-$(CONFIG_ARCH_U8500)	+= ux500/
+ obj-$(CONFIG_ARCH_VT8500)	+= clk-vt8500.o
+ obj-$(CONFIG_ARCH_ZYNQ)		+= zynq/
+ obj-$(CONFIG_ARCH_TEGRA)	+= tegra/
++obj-$(CONFIG_ARCH_OMAP)		+= omap/
+ obj-$(CONFIG_PLAT_SAMSUNG)	+= samsung/
+ 
+ obj-$(CONFIG_X86)		+= x86/
+diff --git a/drivers/clk/omap/Makefile b/drivers/clk/omap/Makefile
+new file mode 100644
+index 0000000..0303c0b
+--- /dev/null
++++ b/drivers/clk/omap/Makefile
+@@ -0,0 +1 @@
++obj-y += clk.o
+diff --git a/drivers/clk/omap/clk.c b/drivers/clk/omap/clk.c
+new file mode 100644
+index 0000000..f7f432d
+--- /dev/null
++++ b/drivers/clk/omap/clk.c
+@@ -0,0 +1,100 @@
++/*
++ * Texas Instruments OMAP Clock driver
++ *
++ * Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
++ * Nishanth Menon <nm@xxxxxx>
++ * Tony Lindgren <tony@xxxxxxxxxxx>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ *
++ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
++ * kind, whether express or implied; without even the implied warranty
++ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ */
++
++#include <linux/clkdev.h>
++#include <linux/clk-provider.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/of_device.h>
++#include <linux/platform_device.h>
++#include <linux/string.h>
++
++static const struct of_device_id omap_clk_of_match[] = {
++    {.compatible = "ti,omap-clock",},
++    {},
++};
++
++/**
++ * omap_clk_src_get() - Get OMAP clock from node name when needed
++ * @clkspec: clkspec argument
++ * @data: unused
++ *
++ * REVISIT: We assume the following:
++ * 1. omap clock names end with _ck
++ * 2. omap clock names are under 32 characters in length
++ */
++static struct clk *omap_clk_src_get(struct of_phandle_args *clkspec, void *data)
++{
++    struct clk *clk;
++    char clk_name[32];
++    struct device_node *np = clkspec->np;
++
++    /* Set up things so consumer can call clk_get() with name */
++    snprintf(clk_name, 32, "%s_ck", np->name);
++    clk = clk_get(NULL, clk_name);
++    if (IS_ERR(clk))
++    {
++        pr_err("%s: could not get clock %s(%ld)\n", __func__,
++        clk_name, PTR_ERR(clk));
++        goto out;
++    }
++    clk_put(clk);
++
++out:
++    return clk;
++}
++
++/**
++ * omap_clk_probe() - create link from DT definition to clock data
++ * @pdev: device node
++ *
++ * NOTE: We assume that omap clocks are not removed.
++ */
++static int omap_clk_probe(struct platform_device *pdev)
++{
++    int res;
++    struct device_node *np = pdev->dev.of_node;
++
++    /* This allows the driver to of_clk_get() */
++    res = of_clk_add_provider(np, omap_clk_src_get, NULL);
++    if (res)
++        dev_err(&pdev->dev, "could not add provider(%d)\n", res);
++
++    return res;
++}
++
++/* We assume here that OMAP clocks will not be removed */
++static struct platform_driver omap_clk_driver =
++{
++    .probe = omap_clk_probe,
++    .driver =
++    {
++        .name = "omap_clk",
++        .of_match_table = of_match_ptr(omap_clk_of_match),
++    },
++};
++
++static int __init omap_clk_init(void)
++{
++    return platform_driver_register(&omap_clk_driver);
++}
++
++arch_initcall(omap_clk_init);
++
++MODULE_DESCRIPTION("OMAP Clock driver");
++MODULE_AUTHOR("Texas Instruments Inc.");
++MODULE_LICENSE("GPL v2");
+-- 
+1.7.10.4
+

--- a/patches/omap/0014-ARM-dts-omap3-add-clock-bindings-to-dts.patch
+++ b/patches/omap/0014-ARM-dts-omap3-add-clock-bindings-to-dts.patch
@@ -1,0 +1,48 @@
+From 49f039bb192f78cf9d1e07c010248dfc2993dc49 Mon Sep 17 00:00:00 2001
+From: Teknoman117 <linux.robotdude@gmail.com>
+Date: Wed, 24 Jul 2013 03:00:18 -0700
+Subject: [PATCH] Add the clock bindings to omap3.dtsi that were made
+ available through the omap-clock device tree driver.  Adds
+ the pll1 clock handles which drives the CPU frequency, and
+ subsequently the ability to change its clock speed, and
+ also add the system reference clock.  Originally found
+ here:
+ http://lkml.indiana.edu/hypermail/linux/kernel/1304.1/04074.html
+
+---
+ arch/arm/boot/dts/omap3.dtsi |   12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/arch/arm/boot/dts/omap3.dtsi b/arch/arm/boot/dts/omap3.dtsi
+index 7d95cda..562f51e 100644
+--- a/arch/arm/boot/dts/omap3.dtsi
++++ b/arch/arm/boot/dts/omap3.dtsi
+@@ -30,6 +30,8 @@
+ 
+ 		cpu@0 {
+ 			compatible = "arm,cortex-a8";
++			clocks = <&dpll1>;
++			clock-names = "cpu";
+ 			device_type = "cpu";
+ 			reg = <0x0>;
+ 		};
+@@ -41,6 +43,16 @@
+ 		ti,hwmods = "debugss";
+ 	};
+ 
++	sysclk: sys {
++		#clock-cells = <0>;
++		compatible = "ti,omap-clock";
++	};
++
++	dpll1: dpll1 {
++		#clock-cells = <0>;
++		compatible = "ti,omap-clock";
++	};
++
+ 	/*
+ 	 * The soc node represents the soc top level view. It is used for IPs
+ 	 * that are not memory mapped in the MPU view or for the MPU itself.
+-- 
+1.7.10.4
+

--- a/patches/omap/0015-ARM-dts-omap-boot-support-cpu0-cpufreq.patch
+++ b/patches/omap/0015-ARM-dts-omap-boot-support-cpu0-cpufreq.patch
@@ -1,0 +1,49 @@
+From 8b6669b06e8e67c8513a0b6700ca62da224478b4 Mon Sep 17 00:00:00 2001
+From: Teknoman117 <linux.robotdude@gmail.com>
+Date: Wed, 24 Jul 2013 03:01:29 -0700
+Subject: [PATCH] Use cpu0-cpufreq in a device tree supported boot.  This is a
+ SoC generic driver, and can pull from the operating points
+ listed in the device tree.  Very nifty - originally found
+ here:
+ http://lkml.indiana.edu/hypermail/linux/kernel/1304.1/04077.html
+
+---
+ arch/arm/mach-omap2/pm.c |   13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/mach-omap2/pm.c b/arch/arm/mach-omap2/pm.c
+index e742118..c959740 100644
+--- a/arch/arm/mach-omap2/pm.c
++++ b/arch/arm/mach-omap2/pm.c
+@@ -266,7 +266,13 @@ static void __init omap4_init_voltages(void)
+ 
+ static inline void omap_init_cpufreq(void)
+ {
+-	struct platform_device_info devinfo = { .name = "omap-cpufreq", };
++	struct platform_device_info devinfo = { };
++
++	if (!of_have_populated_dt())
++		devinfo.name = "omap-cpufreq";
++	else
++		devinfo.name = "cpufreq-cpu0";
++
+ 	platform_device_register_full(&devinfo);
+ }
+ 
+@@ -300,10 +306,11 @@ int __init omap2_common_pm_late_init(void)
+ 		/* Smartreflex device init */
+ 		omap_devinit_smartreflex();
+ 
+-		/* cpufreq dummy device instantiation */
+-		omap_init_cpufreq();
+ 	}
+ 
++	/* cpufreq dummy device instantiation */
++	omap_init_cpufreq();
++
+ #ifdef CONFIG_SUSPEND
+ 	suspend_set_ops(&omap_pm_ops);
+ #endif
+-- 
+1.7.10.4
+

--- a/patches/omap/0016-ARM-dts-omap3-beagle-xm-add-opp1g-abb-bindings.patch
+++ b/patches/omap/0016-ARM-dts-omap3-beagle-xm-add-opp1g-abb-bindings.patch
@@ -1,0 +1,61 @@
+From 15a3c05174edbbb5be9df7976eba85a4d099fe1b Mon Sep 17 00:00:00 2001
+From: Teknoman117 <linux.robotdude@gmail.com>
+Date: Wed, 24 Jul 2013 03:02:20 -0700
+Subject: [PATCH] Now this one is mine lol.  Reading through the ti-abb
+ documentation, I used their example and pulled the proper
+ operating point settings for OPP1G, or the magic 1 GHz
+ point on the Beagleboard xM.  I've added the new operating
+ points to the CPU entry and added the abb bindings for the
+ beagleboard xm.  Its nice that once again, we finally have
+ a safe way of running the BBxM to its specifications after
+ almost a year and a half of stagnating behind the kernel. 
+ Now 3.11-rc2 has 1 GHz support for the BBxM.  So awesome ;)
+
+---
+ arch/arm/boot/dts/omap3-beagle-xm.dts |   27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/arch/arm/boot/dts/omap3-beagle-xm.dts b/arch/arm/boot/dts/omap3-beagle-xm.dts
+index 2273c24..970660e 100644
+--- a/arch/arm/boot/dts/omap3-beagle-xm.dts
++++ b/arch/arm/boot/dts/omap3-beagle-xm.dts
+@@ -16,9 +16,36 @@
+ 	cpus {
+ 		cpu@0 {
+ 			cpu0-supply = <&vcc>;
++			operating-points = <
++				/* kHz    uV */
++				300000   1012500
++				600000   1200000
++				800000   1325000
++				1000000  1380000
++			>;
+ 		};
+ 	};
+ 
++    abb: regulator-abb {
++        compatible = "ti,abb-v1";
++        regulator-name = "abb";
++        #address-cell = <0>;
++        #size-cells = <0>;
++        reg = <0x483072f0 0x8>, <0x48306818 0x4>;
++        reg-names = "base-address", "int-address";
++        ti,tranxdone-status-mask = <0x4000000>;
++        clocks = <&sysclk>;
++        ti,settling-time = <30>;
++        ti,clock-cycles = <8>;
++        ti,abb_info = <
++                /* uV           ABB     efuse   rbb_m   fbb_m   vset_m */
++                1012500         0       0       0       0       0 /* Bypass */
++                1200000         3       0       0       0       0 /* RBB mandatory */
++                1320000         1       0       0       0       0 /* FBB mandatory */
++                1380000         1       0       0       0       0
++        >;
++    };
++
+ 	memory {
+ 		device_type = "memory";
+ 		reg = <0x80000000 0x20000000>; /* 512 MB */
+-- 
+1.7.10.4
+


### PR DESCRIPTION
So I've spent the past day putting together all the information for using texas instrument's abb driver and tracked down a driver that brings the omap clocks into the device tree.  Some modifications to the power management driver to bring up a generic cpufreq driver when performing a dtb boot and added the OPP1G operating point into omap3-beagle-xm.dts.  Works beautifully, and 1 GHz becomes just another cpu frequency setting.  Tested using a Beagleboard xM rev. C I got from digikey in spring 2012.
- Nathaniel Lewis
