### PR TITLE
v4.1.x: Wandboard: DTS with UART2 remapped to GPIO header

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -122,6 +122,7 @@ wand () {
 	echo "dir: wand"
 	${git} "${DIR}/patches/wand/0001-ARM-i.MX6-Wandboard-add-wifi-bt-rfkill-driver.patch"
 	${git} "${DIR}/patches/wand/0002-ARM-dts-wandboard-add-binding-for-wand-rfkill-driver.patch"
+	${git} "${DIR}/patches/wand/0003-dts-imx6q-Add-Wandboard-variant-with-UART2-mapped-to.patch"
 }
 
 errata () {

--- a/patches/wand/0003-dts-imx6q-Add-Wandboard-variant-with-UART2-mapped-to.patch
+++ b/patches/wand/0003-dts-imx6q-Add-Wandboard-variant-with-UART2-mapped-to.patch
@@ -1,0 +1,79 @@
+From 68670032c5922b983936c4f39fdd317251a08e8e Mon Sep 17 00:00:00 2001
+From: Vladimir Ermakov <vooon341@gmail.com>
+Date: Sun, 21 Jun 2015 12:50:58 +0300
+Subject: [PATCH] dts: imx6q: Add Wandboard variant with UART2 mapped to GPIO
+ header.
+
+Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>
+---
+ arch/arm/boot/dts/Makefile                        |  3 +-
+ arch/arm/boot/dts/imx6q-wandboard-revb1-uart2.dts | 43 +++++++++++++++++++++++
+ 2 files changed, 45 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm/boot/dts/imx6q-wandboard-revb1-uart2.dts
+
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index f2e2c5f..e8bce6d 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -314,7 +314,8 @@ dtb-$(CONFIG_SOC_IMX6Q) += \
+ 	imx6q-tx6q-1110.dtb \
+ 	imx6q-udoo.dtb \
+ 	imx6q-wandboard.dtb \
+-	imx6q-wandboard-revb1.dtb
++	imx6q-wandboard-revb1.dtb \
++	imx6q-wandboard-revb1-uart2.dtb
+ dtb-$(CONFIG_SOC_IMX6SL) += \
+ 	imx6sl-evk.dtb \
+ 	imx6sl-evk-wl1835.dtb \
+diff --git a/arch/arm/boot/dts/imx6q-wandboard-revb1-uart2.dts b/arch/arm/boot/dts/imx6q-wandboard-revb1-uart2.dts
+new file mode 100644
+index 0000000..d066be3
+--- /dev/null
++++ b/arch/arm/boot/dts/imx6q-wandboard-revb1-uart2.dts
+@@ -0,0 +1,43 @@
++/*
++ * Copyright 2013 Freescale Semiconductor, Inc.
++ *
++ * Author: Fabio Estevam <fabio.estevam@freescale.com>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ *
++ */
++/dts-v1/;
++#include "imx6q.dtsi"
++#include "imx6qdl-wandboard-revb1.dtsi"
++
++/ {
++	model = "Wandboard i.MX6 Quad Board (UART2)";
++	compatible = "wand,imx6q-wandboard", "fsl,imx6q";
++
++	memory {
++		reg = <0x10000000 0x80000000>;
++	};
++};
++
++&sata {
++	status = "okay";
++};
++
++&iomuxc {
++	imx6qdl-wandboard {
++		pinctrl_uart2: uarg2grp {
++			fsl,pins = <
++				MX6QDL_PAD_EIM_D26__UART2_TX_DATA 0x1b0b1
++				MX6QDL_PAD_EIM_D27__UART2_RX_DATA 0x1b0b1
++			>;
++		};
++	};
++};
++
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart2>;
++	status = "okay";
++};
+-- 
+2.1.4
+


### PR DESCRIPTION
Hello.
This DT variant do remap GPIO3_26 and GPIO2_27 to UART2.
That config might be useful when you want to connect some peripheral (pixhawk in my case :) ) to wandboard and see that hw only provide one com port for console.
