### PR TITLE
Added optional manual override for 'make -j' CPU cores.

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -21,7 +21,6 @@
 # THE SOFTWARE.
 
 DIR=$PWD
-CORES=$(getconf _NPROCESSORS_ONLN)
 git_bin=$(which git)
 
 mkdir -p "${DIR}/deploy/"
@@ -229,6 +228,10 @@ fi
 
 . "${DIR}/version.sh"
 export LINUX_GIT
+
+if [ ! "${CORES}" ] ; then
+	CORES=$(getconf _NPROCESSORS_ONLN)
+fi
 
 #unset FULL_REBUILD
 FULL_REBUILD=1

--- a/system.sh.sample
+++ b/system.sh.sample
@@ -19,6 +19,9 @@ fi
 
 ###OPTIONAL:
 
+###OPTIONAL: CORES: number of CPU cores to use for compilation
+#CORES=4
+
 ###OPTIONAL: LINUX_GIT: specify location of locally cloned git tree.
 #
 #LINUX_GIT=/home/user/linux-stable/


### PR DESCRIPTION
Make CPU cores is usually defined in build_kernel.sh by the number of CPU
cores detected in the system. This patch adds the facility to manually
override this detection in the system.sh script.

Suggested-By: M. J. Everitt <m.j.everitt@iee.org>