### PR TITLE
Update `check_dpkg` function.

### DIFF
--- a/tools/host_det.sh
+++ b/tools/host_det.sh
@@ -121,7 +121,7 @@ Missing patch command,
 }
 
 check_dpkg () {
-	LC_ALL=C dpkg --list | awk '{print $2}' | grep "^${pkg}$" >/dev/null || deb_pkgs="${deb_pkgs}${pkg} "
+	LC_ALL=C dpkg-query -s ${pkg} &> /dev/null || deb_pkgs="${deb_pkgs}${pkg} "
 }
 
 debian_regs () {


### PR DESCRIPTION
While running `build_kernel.sh`, I got this message:

```
Debian/Ubuntu/Mint: missing dependencies, please install:
-----------------------------
sudo apt-get update
sudo apt-get install libncurses5-dev:amd64
-----------------------------
* Failed dependency check
```

Even though the package it’s complaining about is installed.  The
command used to determine if a package is installed is:

`LC_ALL=C dpkg --list | awk '{print $2}' | grep libncurses`

When this is run, it outputs:

```
libncurses5:amd64
libncurses5-dev:a
libncursesw5:amd6
```

This is because `dpkg` truncates the package name to show columnar
information.

Instead of using this rather roundabout method, use `dpkg-query`
instead.